### PR TITLE
Buggfix för projektstegsknapparna

### DIFF
--- a/stylesheets/base/buttons.scss
+++ b/stylesheets/base/buttons.scss
@@ -90,7 +90,7 @@ a.btn {
     font-size: 14px;
 }
 a.btn:hover {
-    color: #4e4e4e;
+    color: #4e4e4e !important;
 }
 .buttonsField {
     display: block;


### PR DESCRIPTION
Fixar en bugg med projektstegsknapparna i menyraden på toppen av sidan som stoppar de från att byta färg när musen hålls över dem.